### PR TITLE
Prepare for release v0.4.0-beta.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	k8s.io/kubectl v0.18.3
 	kmodules.xyz/client-go v0.0.0-20200630053911-20d035822d35
 	kmodules.xyz/custom-resources v0.0.0-20200604135349-9e9f5c4fdba9
-	kubevault.dev/operator v0.4.0-alpha.0.0.20200703093608-01289e5c19a4
+	kubevault.dev/operator v0.4.0-beta.0
 )
 
 replace (

--- a/go.sum
+++ b/go.sum
@@ -1402,8 +1402,8 @@ kmodules.xyz/offshoot-api v0.0.0-20200521035628-e135bf07b226 h1:RZ7H0gl1z/9jLI74
 kmodules.xyz/offshoot-api v0.0.0-20200521035628-e135bf07b226/go.mod h1:IbK+hCI23UfTDMzG7hos9sERCase2xsFK+XC0Ns3OCg=
 kmodules.xyz/openshift v0.0.0-20200522123204-ce4abf5433c8/go.mod h1:nVhGcoB3Bi7Ots5+g972Ap/vtyIrrtoK3Z3aulNux7w=
 kmodules.xyz/webhook-runtime v0.0.0-20200522123600-ca70a7e28ed0/go.mod h1:9hUftUcjvzDSiO5LIbe2U8Naz4tyS9Ndf1LRzsytMzs=
-kubevault.dev/operator v0.4.0-alpha.0.0.20200703093608-01289e5c19a4 h1:nMdlpwUxTdpzs9TiTVoytvSAEvT1tuAuC2aF/wX/xSU=
-kubevault.dev/operator v0.4.0-alpha.0.0.20200703093608-01289e5c19a4/go.mod h1:ozEFcx3LwalnhxtDCXyLPXgWnwq+y3d1OZ3sjur/w9c=
+kubevault.dev/operator v0.4.0-beta.0 h1:58KwT6dQcNReiNsHCon/HfYqDwMnKaDsv+sPHSngQn4=
+kubevault.dev/operator v0.4.0-beta.0/go.mod h1:ozEFcx3LwalnhxtDCXyLPXgWnwq+y3d1OZ3sjur/w9c=
 layeh.com/radius v0.0.0-20190322222518-890bc1058917/go.mod h1:fywZKyu//X7iRzaxLgPWsvc0L26IUpVvE/aeIL2JtIQ=
 modernc.org/cc v1.0.0/go.mod h1:1Sk4//wdnYJiUIxnW8ddKpaOJCF37yAdqYnkxUpaYxw=
 modernc.org/golex v1.0.0/go.mod h1:b/QX9oBD/LhixY6NDh+IdGv17hgB+51fET1i2kPSmvk=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -450,7 +450,7 @@ kmodules.xyz/custom-resources/crds
 kmodules.xyz/monitoring-agent-api/api/v1
 # kmodules.xyz/offshoot-api v0.0.0-20200521035628-e135bf07b226
 kmodules.xyz/offshoot-api/api/v1
-# kubevault.dev/operator v0.4.0-alpha.0.0.20200703093608-01289e5c19a4
+# kubevault.dev/operator v0.4.0-beta.0
 ## explicit
 kubevault.dev/operator/api/crds
 kubevault.dev/operator/apis/catalog


### PR DESCRIPTION
ProductLine: KubeVault
Release: v2020.07.09-beta.0
Release-tracker: https://github.com/kubevault/CHANGELOG/pull/3
Signed-off-by: 1gtm <1gtm@appscode.com>