### PR TITLE
Prepare for release v0.4.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	k8s.io/kubectl v0.21.0
 	kmodules.xyz/client-go v0.0.0-20210719120358-dd0503cf99cf
 	kmodules.xyz/custom-resources v0.0.0-20210727045435-83db827677cf
-	kubevault.dev/apimachinery v0.4.0-rc.0.0.20210727072740-777c84acb2eb
+	kubevault.dev/apimachinery v0.4.0
 )
 
 replace bitbucket.org/ww/goautoneg => gomodules.xyz/goautoneg v0.0.0-20120707110453-a547fc61f48d

--- a/go.sum
+++ b/go.sum
@@ -829,15 +829,14 @@ kmodules.xyz/client-go v0.0.0-20210715065708-d4f0cc74ead1/go.mod h1:E/vGngai00Ut
 kmodules.xyz/client-go v0.0.0-20210719120358-dd0503cf99cf h1:1TvaFkf0/6HcsN8jJUKiLmydB/NqkPSIFsAoGJsSIjc=
 kmodules.xyz/client-go v0.0.0-20210719120358-dd0503cf99cf/go.mod h1:E/vGngai00UtVwP8R4PWpPUBF/EZa6Ub9WS5+tVcs4M=
 kmodules.xyz/crd-schema-fuzz v0.0.0-20210618002152-fae23aef5fb4/go.mod h1:IIkUctlfoptoci0BOrsUf8ya+MOG5uaeh1PE4uzaIbA=
-kmodules.xyz/custom-resources v0.0.0-20210618003440-c6bb400da153/go.mod h1:/NLuNSf299U0XVuNEh2swtw3EczWFRL3Sx24WhNoWCM=
 kmodules.xyz/custom-resources v0.0.0-20210727045435-83db827677cf h1:Ig7rQXvbp3HQsSEaFCpXvA/mk+Xw6IQyJGx1rHdMhsE=
 kmodules.xyz/custom-resources v0.0.0-20210727045435-83db827677cf/go.mod h1:VYtz1fgHgLqCk+sdSUGBClfZfJ6z4873wB5MYOXxpS8=
 kmodules.xyz/monitoring-agent-api v0.0.0-20210618110729-9cd872c66513 h1:vH9mvqU2i84Zdo70N87Ck3vRQdu4SsHpo67p0MKsWzU=
 kmodules.xyz/monitoring-agent-api v0.0.0-20210618110729-9cd872c66513/go.mod h1:QsbPe5SefM7XmLzJgdMX/1iXxwqAC1Do1eHa98TCq3k=
 kmodules.xyz/offshoot-api v0.0.0-20210618005544-5217a24765da h1:hszFiNuYyYkg88FJpIKqBLX0kSt7sXKO+m3cLfrWMCA=
 kmodules.xyz/offshoot-api v0.0.0-20210618005544-5217a24765da/go.mod h1:3LECbAL3FgbyK80NP3V3Pmiuo/a3hFWg/PR6SPFhTns=
-kubevault.dev/apimachinery v0.4.0-rc.0.0.20210727072740-777c84acb2eb h1:JKkYXayioh7iGCNa0GXwPObvf1PEUz3XhZXz2ana/Ak=
-kubevault.dev/apimachinery v0.4.0-rc.0.0.20210727072740-777c84acb2eb/go.mod h1:gxBp4hXTaizHcIZ/+fWjHjAfaDDPEc4h4sUv7XyM6Qo=
+kubevault.dev/apimachinery v0.4.0 h1:L9hEHGJKW8hRcJ5ChiNL9Q6F8si1/G6Ia60yJAeYlKs=
+kubevault.dev/apimachinery v0.4.0/go.mod h1:k5NJMq8osjO5ZefKZCfSYKVXxwUs9vbw3nNIVz+lB5s=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.15/go.mod h1:LEScyzhFmoF5pso/YSeBstl57mOzx9xlU9n85RGrDQg=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -566,7 +566,7 @@ kmodules.xyz/custom-resources/crds
 kmodules.xyz/monitoring-agent-api/api/v1
 # kmodules.xyz/offshoot-api v0.0.0-20210618005544-5217a24765da
 kmodules.xyz/offshoot-api/api/v1
-# kubevault.dev/apimachinery v0.4.0-rc.0.0.20210727072740-777c84acb2eb
+# kubevault.dev/apimachinery v0.4.0
 ## explicit
 kubevault.dev/apimachinery/apis
 kubevault.dev/apimachinery/apis/catalog


### PR DESCRIPTION
ProductLine: KubeVault
Release: v2021.08.02
Release-tracker: https://github.com/kubevault/CHANGELOG/pull/19
Signed-off-by: 1gtm <1gtm@appscode.com>