### PR TITLE
Prepare for release v0.5.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	k8s.io/kubectl v0.21.0
 	kmodules.xyz/client-go v0.0.0-20210921150324-f005c6dfcb32
 	kmodules.xyz/custom-resources v0.0.0-20210829135624-c63be82e13c0
-	kubevault.dev/apimachinery v0.4.1-0.20210922053854-428a8125a307
+	kubevault.dev/apimachinery v0.5.0
 )
 
 replace bitbucket.org/ww/goautoneg => gomodules.xyz/goautoneg v0.0.0-20120707110453-a547fc61f48d

--- a/go.sum
+++ b/go.sum
@@ -845,8 +845,8 @@ kmodules.xyz/monitoring-agent-api v0.0.0-20210902163558-0323c6034f70 h1:qO7LtxB7
 kmodules.xyz/monitoring-agent-api v0.0.0-20210902163558-0323c6034f70/go.mod h1:08pBqfEuy29EjhaMrHB2XFy2iekoFi7AjaXcJS+xAck=
 kmodules.xyz/offshoot-api v0.0.0-20210829122105-6f4d481b0c61 h1:J56UGmRFddu6tERRd8BELmP5QbXxievzb+6vAjFptiM=
 kmodules.xyz/offshoot-api v0.0.0-20210829122105-6f4d481b0c61/go.mod h1:3LECbAL3FgbyK80NP3V3Pmiuo/a3hFWg/PR6SPFhTns=
-kubevault.dev/apimachinery v0.4.1-0.20210922053854-428a8125a307 h1:xAD6TKETFuvvonQG/YWimXRTpTSPFanVSBs/s1hTtpk=
-kubevault.dev/apimachinery v0.4.1-0.20210922053854-428a8125a307/go.mod h1:aGIAaCWQtYhv6BeFt8IdgIIdbFHadK/U5ElG7lu3TFk=
+kubevault.dev/apimachinery v0.5.0 h1:lPaVZfgM0FBvsGHjUc8+9UmZVR0cQpp5Iy/+Yd6HvGk=
+kubevault.dev/apimachinery v0.5.0/go.mod h1:aGIAaCWQtYhv6BeFt8IdgIIdbFHadK/U5ElG7lu3TFk=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.15/go.mod h1:LEScyzhFmoF5pso/YSeBstl57mOzx9xlU9n85RGrDQg=

--- a/vendor/kubevault.dev/apimachinery/apis/engine/v1alpha1/secret_role_binding_helpers.go
+++ b/vendor/kubevault.dev/apimachinery/apis/engine/v1alpha1/secret_role_binding_helpers.go
@@ -17,9 +17,12 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"fmt"
+
 	"kubevault.dev/apimachinery/crds"
 
 	"kmodules.xyz/client-go/apiextensions"
+	meta_util "kmodules.xyz/client-go/meta"
 )
 
 func (_ SecretRoleBinding) CustomResourceDefinition() *apiextensions.CustomResourceDefinition {
@@ -28,4 +31,12 @@ func (_ SecretRoleBinding) CustomResourceDefinition() *apiextensions.CustomResou
 
 func (d SecretRoleBinding) IsValid() error {
 	return nil
+}
+
+func (srb SecretRoleBinding) VaultPolicyName() string {
+	return meta_util.NameWithPrefix("srb", fmt.Sprintf("%s-%s", srb.Namespace, srb.Name))
+}
+
+func (srb SecretRoleBinding) VaultPolicyBindingName() string {
+	return meta_util.NameWithPrefix("srb", fmt.Sprintf("%s-%s", srb.Namespace, srb.Name))
 }

--- a/vendor/kubevault.dev/apimachinery/apis/engine/v1alpha1/type.go
+++ b/vendor/kubevault.dev/apimachinery/apis/engine/v1alpha1/type.go
@@ -62,3 +62,24 @@ type RoleStatus struct {
 
 	PolicyRef *kmapi.ObjectReference `json:"policyRef,omitempty" protobuf:"bytes,4,opt,name=policyRef"`
 }
+
+const (
+	SecretRoleBindingAnnotationName      = "secretrolebindings.engine.kubevault.com/name"
+	SecretRoleBindingAnnotationNamespace = "secretrolebindings.engine.kubevault.com/namespace"
+)
+
+// SecretRoleBinding Phases
+
+const (
+	SecretRoleBindingPhaseSuccess    RequestStatusPhase = "Success"
+	SecretRoleBindingPhaseProcessing RequestStatusPhase = "Processing"
+	SecretRoleBindingPhaseFailed     RequestStatusPhase = "Failed"
+)
+
+// SecretRoleBinding Conditions
+
+const (
+	VaultPolicySuccess        = "VaultPolicySuccess"
+	VaultPolicyBindingSuccess = "VaultPolicyBindingSuccess"
+	SecretRoleBindingSuccess  = "SecretRoleBindingSuccess"
+)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -567,7 +567,7 @@ kmodules.xyz/custom-resources/crds
 kmodules.xyz/monitoring-agent-api/api/v1
 # kmodules.xyz/offshoot-api v0.0.0-20210829122105-6f4d481b0c61
 kmodules.xyz/offshoot-api/api/v1
-# kubevault.dev/apimachinery v0.4.1-0.20210922053854-428a8125a307
+# kubevault.dev/apimachinery v0.5.0
 ## explicit
 kubevault.dev/apimachinery/apis
 kubevault.dev/apimachinery/apis/catalog


### PR DESCRIPTION
ProductLine: KubeVault
Release: v2021.09.27
Release-tracker: https://github.com/kubevault/CHANGELOG/pull/21
Signed-off-by: 1gtm <1gtm@appscode.com>