### PR TITLE
Prepare for release v0.5.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	k8s.io/kubectl v0.21.0
 	kmodules.xyz/client-go v0.0.0-20210928133955-8df5bb467db6
 	kmodules.xyz/custom-resources v0.0.0-20211007080833-72bd9e8cae6e
-	kubevault.dev/apimachinery v0.5.1-0.20211007084135-90b49fc8bcf6
+	kubevault.dev/apimachinery v0.5.1
 )
 
 replace bitbucket.org/ww/goautoneg => gomodules.xyz/goautoneg v0.0.0-20120707110453-a547fc61f48d

--- a/go.sum
+++ b/go.sum
@@ -849,8 +849,8 @@ kmodules.xyz/monitoring-agent-api v0.0.0-20210928135619-38ca075a2dbd/go.mod h1:0
 kmodules.xyz/offshoot-api v0.0.0-20210829122105-6f4d481b0c61 h1:J56UGmRFddu6tERRd8BELmP5QbXxievzb+6vAjFptiM=
 kmodules.xyz/offshoot-api v0.0.0-20210829122105-6f4d481b0c61/go.mod h1:3LECbAL3FgbyK80NP3V3Pmiuo/a3hFWg/PR6SPFhTns=
 kmodules.xyz/resource-metrics v0.0.5/go.mod h1:6Dv63HDgp83DhA+lZNB7GIQR6PLjNrYW6ghQKioQzII=
-kubevault.dev/apimachinery v0.5.1-0.20211007084135-90b49fc8bcf6 h1:YZoaFkICq3WwPYl3tFuxrB+aDGbe9rL3bgrmN1PCxz0=
-kubevault.dev/apimachinery v0.5.1-0.20211007084135-90b49fc8bcf6/go.mod h1:/zqe2mpDe36alND3bH3G9bAiXtuJ/IhQvXvvl8ctoDs=
+kubevault.dev/apimachinery v0.5.1 h1:0j5a1ywGKkHWRycNBjEfFjyxueCwpGqfS+vKOFO/TlI=
+kubevault.dev/apimachinery v0.5.1/go.mod h1:unw6QsWINVeSB0qyk/ioqp07+yNrXHsrUd759hxoxzs=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.15/go.mod h1:LEScyzhFmoF5pso/YSeBstl57mOzx9xlU9n85RGrDQg=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -567,7 +567,7 @@ kmodules.xyz/custom-resources/crds
 kmodules.xyz/monitoring-agent-api/api/v1
 # kmodules.xyz/offshoot-api v0.0.0-20210829122105-6f4d481b0c61
 kmodules.xyz/offshoot-api/api/v1
-# kubevault.dev/apimachinery v0.5.1-0.20211007084135-90b49fc8bcf6
+# kubevault.dev/apimachinery v0.5.1
 ## explicit
 kubevault.dev/apimachinery/apis
 kubevault.dev/apimachinery/apis/catalog


### PR DESCRIPTION
ProductLine: KubeVault
Release: v2021.10.11
Release-tracker: https://github.com/kubevault/CHANGELOG/pull/22
Signed-off-by: 1gtm <1gtm@appscode.com>