### PR TITLE
Prepare for release v0.6.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	k8s.io/kubectl v0.21.0
 	kmodules.xyz/client-go v0.0.0-20211028132207-0cf6ea46b030
 	kmodules.xyz/custom-resources v0.0.0-20211007080833-72bd9e8cae6e
-	kubevault.dev/apimachinery v0.5.2-0.20211222093623-2fa206cc7bc6
+	kubevault.dev/apimachinery v0.6.0
 	sigs.k8s.io/secrets-store-csi-driver v1.0.0
 	sigs.k8s.io/yaml v1.2.0
 )

--- a/go.sum
+++ b/go.sum
@@ -931,8 +931,8 @@ kmodules.xyz/monitoring-agent-api v0.0.0-20210928135619-38ca075a2dbd/go.mod h1:0
 kmodules.xyz/offshoot-api v0.0.0-20210829122105-6f4d481b0c61 h1:J56UGmRFddu6tERRd8BELmP5QbXxievzb+6vAjFptiM=
 kmodules.xyz/offshoot-api v0.0.0-20210829122105-6f4d481b0c61/go.mod h1:3LECbAL3FgbyK80NP3V3Pmiuo/a3hFWg/PR6SPFhTns=
 kmodules.xyz/resource-metrics v0.0.5/go.mod h1:6Dv63HDgp83DhA+lZNB7GIQR6PLjNrYW6ghQKioQzII=
-kubevault.dev/apimachinery v0.5.2-0.20211222093623-2fa206cc7bc6 h1:aRjXKG8Pu8njDKCVCJ7uWkVNuRbQWCTz9UhTHYE5SU0=
-kubevault.dev/apimachinery v0.5.2-0.20211222093623-2fa206cc7bc6/go.mod h1:syJiwQdeAiXG8+4j2I9G8S9Hhp+r5sxu/bzO8t0Ik2s=
+kubevault.dev/apimachinery v0.6.0 h1:yxRPUSWtL5faoyOv8I64hibxUGnOV27ki6KpWIOAKbQ=
+kubevault.dev/apimachinery v0.6.0/go.mod h1:syJiwQdeAiXG8+4j2I9G8S9Hhp+r5sxu/bzO8t0Ik2s=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.15/go.mod h1:LEScyzhFmoF5pso/YSeBstl57mOzx9xlU9n85RGrDQg=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -832,7 +832,7 @@ kmodules.xyz/custom-resources/crds
 kmodules.xyz/monitoring-agent-api/api/v1
 # kmodules.xyz/offshoot-api v0.0.0-20210829122105-6f4d481b0c61
 kmodules.xyz/offshoot-api/api/v1
-# kubevault.dev/apimachinery v0.5.2-0.20211222093623-2fa206cc7bc6
+# kubevault.dev/apimachinery v0.6.0
 ## explicit
 kubevault.dev/apimachinery/apis
 kubevault.dev/apimachinery/apis/catalog


### PR DESCRIPTION
ProductLine: KubeVault
Release: v2022.01.11
Release-tracker: https://github.com/kubevault/CHANGELOG/pull/24
Signed-off-by: 1gtm <1gtm@appscode.com>