### PR TITLE
Prepare for release v0.7.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	k8s.io/kubectl v0.21.0
 	kmodules.xyz/client-go v0.0.0-20220203031013-1de48437aaf3
 	kmodules.xyz/custom-resources v0.0.0-20220208103158-61b298634e43
-	kubevault.dev/apimachinery v0.6.1-0.20220208195407-29e4aefeefca
+	kubevault.dev/apimachinery v0.7.0
 	sigs.k8s.io/secrets-store-csi-driver v1.0.0
 	sigs.k8s.io/yaml v1.2.0
 )

--- a/go.sum
+++ b/go.sum
@@ -982,8 +982,8 @@ kmodules.xyz/offshoot-api v0.0.0-20210829122105-6f4d481b0c61/go.mod h1:3LECbAL3F
 kmodules.xyz/offshoot-api v0.0.0-20211207130839-cc7187e020cf h1:cVaxFPsZyaymGsx4XoTii1MEvtwGxmLg75qwMxNHB4w=
 kmodules.xyz/offshoot-api v0.0.0-20211207130839-cc7187e020cf/go.mod h1:sJYyxf84ZvbVz4SivxMgSelGRYn19wOLUtObiEncCxk=
 kmodules.xyz/resource-metrics v0.0.6/go.mod h1:M7rWuo2qh3BpHhogiEVPnvGY9Xx4Pfygqn1Rex8YbgM=
-kubevault.dev/apimachinery v0.6.1-0.20220208195407-29e4aefeefca h1:SIgmQC/9X4bFVlyyiuXEu4DEpTADJIdTdEGJou5uuCQ=
-kubevault.dev/apimachinery v0.6.1-0.20220208195407-29e4aefeefca/go.mod h1:uMRH672cdQ7jtDjTVjkGzcGzHGoHAn3Ckl/jGn/fW/E=
+kubevault.dev/apimachinery v0.7.0 h1:tpx443igffubVvufIcrmaoRq6OeHrMgOQAKqQXeKF0M=
+kubevault.dev/apimachinery v0.7.0/go.mod h1:uMRH672cdQ7jtDjTVjkGzcGzHGoHAn3Ckl/jGn/fW/E=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.15/go.mod h1:LEScyzhFmoF5pso/YSeBstl57mOzx9xlU9n85RGrDQg=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -840,7 +840,7 @@ kmodules.xyz/custom-resources/crds
 kmodules.xyz/monitoring-agent-api/api/v1
 # kmodules.xyz/offshoot-api v0.0.0-20211207130839-cc7187e020cf
 kmodules.xyz/offshoot-api/api/v1
-# kubevault.dev/apimachinery v0.6.1-0.20220208195407-29e4aefeefca
+# kubevault.dev/apimachinery v0.7.0
 ## explicit
 kubevault.dev/apimachinery/apis
 kubevault.dev/apimachinery/apis/catalog


### PR DESCRIPTION
ProductLine: KubeVault
Release: v2022.02.22
Release-tracker: https://github.com/kubevault/CHANGELOG/pull/26
Signed-off-by: 1gtm <1gtm@appscode.com>