### PR TITLE
Prepare for release v0.12.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	k8s.io/kubectl v0.25.1
 	kmodules.xyz/client-go v0.25.6
 	kmodules.xyz/custom-resources v0.25.0
-	kubevault.dev/apimachinery v0.11.0
+	kubevault.dev/apimachinery v0.12.0
 	sigs.k8s.io/secrets-store-csi-driver v1.2.4
 	sigs.k8s.io/yaml v1.3.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1186,8 +1186,8 @@ kmodules.xyz/monitoring-agent-api v0.25.0 h1:RU9RBeCqQdoS381xXy8cM1aqT+7qmtuPI3K
 kmodules.xyz/monitoring-agent-api v0.25.0/go.mod h1:RH5f/W9eCiW+KTblBIh8MZkjCWdtMQ8MuzCBMfgkynM=
 kmodules.xyz/offshoot-api v0.25.0 h1:Svq9da/+sg5afOjpgo9vx2J/Lu90Mo0aFxkdQmgKnGI=
 kmodules.xyz/offshoot-api v0.25.0/go.mod h1:ysEBn7LJuT3+s8ynAQA/OG0BSsJugXa6KGtDLMRjlKo=
-kubevault.dev/apimachinery v0.11.0 h1:zMHHKkAmyZ3qWxPlAEdgoYaAW5+AGK737NoR0JSQZJU=
-kubevault.dev/apimachinery v0.11.0/go.mod h1:fUzeVdoB8pVr0qlDJMvGEDZfuio65ktuXpByafdPCqs=
+kubevault.dev/apimachinery v0.12.0 h1:A2A7P06p+GSrKtb1Ticqg+/lcwX/sdXGQNDwOFUjtJM=
+kubevault.dev/apimachinery v0.12.0/go.mod h1:fUzeVdoB8pVr0qlDJMvGEDZfuio65ktuXpByafdPCqs=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=

--- a/vendor/kubevault.dev/apimachinery/apis/config/v1alpha1/openapi_generated.go
+++ b/vendor/kubevault.dev/apimachinery/apis/config/v1alpha1/openapi_generated.go
@@ -19493,10 +19493,23 @@ func schema_apimachinery_apis_config_v1alpha1_VaultServerConfiguration(ref commo
 							Ref:         ref("kmodules.xyz/custom-resources/apis/appcatalog/v1alpha1.StashAddonSpec"),
 						},
 					},
+					"backend": {
+						SchemaProps: spec.SchemaProps{
+							Description: "backend storage information for vault",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"unsealer": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Unsealer configuration for vault",
+							Ref:         ref("kubevault.dev/apimachinery/apis/kubevault/v1alpha2.UnsealerSpec"),
+						},
+					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"k8s.io/api/core/v1.LocalObjectReference", "kmodules.xyz/custom-resources/apis/appcatalog/v1alpha1.StashAddonSpec", "kubevault.dev/apimachinery/apis/config/v1alpha1.AWSAuthConfig", "kubevault.dev/apimachinery/apis/config/v1alpha1.AzureAuthConfig", "kubevault.dev/apimachinery/apis/config/v1alpha1.KubernetesAuthConfig"},
+			"k8s.io/api/core/v1.LocalObjectReference", "kmodules.xyz/custom-resources/apis/appcatalog/v1alpha1.StashAddonSpec", "kubevault.dev/apimachinery/apis/config/v1alpha1.AWSAuthConfig", "kubevault.dev/apimachinery/apis/config/v1alpha1.AzureAuthConfig", "kubevault.dev/apimachinery/apis/config/v1alpha1.KubernetesAuthConfig", "kubevault.dev/apimachinery/apis/kubevault/v1alpha2.UnsealerSpec"},
 	}
 }

--- a/vendor/kubevault.dev/apimachinery/apis/config/v1alpha1/vault_server_config_types.go
+++ b/vendor/kubevault.dev/apimachinery/apis/config/v1alpha1/vault_server_config_types.go
@@ -17,6 +17,8 @@ limitations under the License.
 package v1alpha1
 
 import (
+	kubevaultv1alpha2 "kubevault.dev/apimachinery/apis/kubevault/v1alpha2"
+
 	core "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	appcat "kmodules.xyz/custom-resources/apis/appcatalog/v1alpha1"
@@ -62,6 +64,14 @@ type VaultServerConfiguration struct {
 	// Stash defines backup and restore task definitions.
 	// +optional
 	Stash appcat.StashAddonSpec `json:"stash,omitempty"`
+
+	// backend storage information for vault
+	// +optional
+	Backend kubevaultv1alpha2.VaultServerBackend `json:"backend,omitempty"`
+
+	// Unsealer configuration for vault
+	// +optional
+	Unsealer *kubevaultv1alpha2.UnsealerSpec `json:"unsealer,omitempty"`
 }
 
 // KubernetesAuthConfiguration contains necessary information for

--- a/vendor/kubevault.dev/apimachinery/apis/config/v1alpha1/zz_generated.deepcopy.go
+++ b/vendor/kubevault.dev/apimachinery/apis/config/v1alpha1/zz_generated.deepcopy.go
@@ -22,6 +22,8 @@ limitations under the License.
 package v1alpha1
 
 import (
+	v1alpha2 "kubevault.dev/apimachinery/apis/kubevault/v1alpha2"
+
 	v1 "k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
@@ -99,6 +101,11 @@ func (in *VaultServerConfiguration) DeepCopyInto(out *VaultServerConfiguration) 
 		**out = **in
 	}
 	in.Stash.DeepCopyInto(&out.Stash)
+	if in.Unsealer != nil {
+		in, out := &in.Unsealer, &out.Unsealer
+		*out = new(v1alpha2.UnsealerSpec)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1092,7 +1092,7 @@ kmodules.xyz/monitoring-agent-api/api/v1
 # kmodules.xyz/offshoot-api v0.25.0
 ## explicit; go 1.18
 kmodules.xyz/offshoot-api/api/v1
-# kubevault.dev/apimachinery v0.11.0
+# kubevault.dev/apimachinery v0.12.0
 ## explicit; go 1.18
 kubevault.dev/apimachinery/apis
 kubevault.dev/apimachinery/apis/catalog


### PR DESCRIPTION
ProductLine: KubeVault
Release: v2022.12.09
Release-tracker: https://github.com/kubevault/CHANGELOG/pull/35
Signed-off-by: 1gtm <1gtm@appscode.com>