### PR TITLE
Prepare for release v0.17.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	k8s.io/kubectl v0.29.0
 	kmodules.xyz/client-go v0.29.6
 	kmodules.xyz/custom-resources v0.29.1
-	kubevault.dev/apimachinery v0.17.0-rc.1
+	kubevault.dev/apimachinery v0.17.0
 	sigs.k8s.io/secrets-store-csi-driver v1.3.3
 	sigs.k8s.io/yaml v1.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -851,8 +851,8 @@ kmodules.xyz/monitoring-agent-api v0.29.0 h1:gpFl6OZrlMLb/ySMHdREI9EwGtnJ91oZBn9
 kmodules.xyz/monitoring-agent-api v0.29.0/go.mod h1:iNbvaMTgVFOI5q2LJtGK91j4Dmjv4ZRiRdasGmWLKQI=
 kmodules.xyz/offshoot-api v0.29.0 h1:GHLhxxT9jU1N8+FvOCCeJNyU5g0duYS46UGrs6AHNLY=
 kmodules.xyz/offshoot-api v0.29.0/go.mod h1:5NxhBblXoDHWStx9HCDJR2KFTwYjEZ7i1Id3jelIunw=
-kubevault.dev/apimachinery v0.17.0-rc.1 h1:PdMsprgzAPEYSWiz7IrTT83ZjVku2poLgSMac0XlARo=
-kubevault.dev/apimachinery v0.17.0-rc.1/go.mod h1:ImeKe0ZBHRHzbfZNPb25lS53CDaAh5daXj/W/G2ag5Q=
+kubevault.dev/apimachinery v0.17.0 h1:6NpSSTCk2ZeFTGb4DEVEzHZYAN2d6Nz36borHHevuFM=
+kubevault.dev/apimachinery v0.17.0/go.mod h1:ImeKe0ZBHRHzbfZNPb25lS53CDaAh5daXj/W/G2ag5Q=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd h1:EDPBXCAspyGV4jQlpZSudPeMmr1bNJefnuqLsRAsHZo=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd/go.mod h1:B8JuhiUyNFVKdsE8h686QcCxMaH6HrOAZj4vswFpcB0=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1222,7 +1222,7 @@ kmodules.xyz/monitoring-agent-api/api/v1
 # kmodules.xyz/offshoot-api v0.29.0
 ## explicit; go 1.21.5
 kmodules.xyz/offshoot-api/api/v1
-# kubevault.dev/apimachinery v0.17.0-rc.1
+# kubevault.dev/apimachinery v0.17.0
 ## explicit; go 1.21.5
 kubevault.dev/apimachinery/apis
 kubevault.dev/apimachinery/apis/catalog


### PR DESCRIPTION
ProductLine: KubeVault
Release: v2024.1.31
Release-tracker: https://github.com/kubevault/CHANGELOG/pull/48
Signed-off-by: 1gtm <1gtm@appscode.com>