### PR TITLE
Prepare for release v0.20.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	k8s.io/kubectl v0.30.2
 	kmodules.xyz/client-go v0.30.45
 	kmodules.xyz/custom-resources v0.30.0
-	kubevault.dev/apimachinery v0.20.0-rc.0
+	kubevault.dev/apimachinery v0.20.0
 	sigs.k8s.io/secrets-store-csi-driver v1.4.8
 	sigs.k8s.io/yaml v1.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -758,8 +758,8 @@ kmodules.xyz/monitoring-agent-api v0.30.2 h1:sAgz5P5EXZqhlj1NzJ+QltAgeIx5bGSMj+a
 kmodules.xyz/monitoring-agent-api v0.30.2/go.mod h1:BoZFPDDRB7J39CcUsSDlzgW8PQCwik4ILPleyUob+Mg=
 kmodules.xyz/offshoot-api v0.30.1 h1:TrulAYO+oBsXe9sZZGTmNWIuI8qD2izMpgcTSPvgAmI=
 kmodules.xyz/offshoot-api v0.30.1/go.mod h1:T3mpjR6fui0QzOcmQvIuANytW48fe9ytmy/1cgx6D4g=
-kubevault.dev/apimachinery v0.20.0-rc.0 h1:cDpGbkYoWIleoGUGkG9y6SO6v1uDJIzO0lTCva4Pbnk=
-kubevault.dev/apimachinery v0.20.0-rc.0/go.mod h1:IWNygSeZJ8ycABG+UFuDeU9kj4NN1z9QOx65FUbj4lY=
+kubevault.dev/apimachinery v0.20.0 h1:f675GTbuj6820ReLyg/KLoX5eXvDx8/r6LqgegweyMQ=
+kubevault.dev/apimachinery v0.20.0/go.mod h1:IWNygSeZJ8ycABG+UFuDeU9kj4NN1z9QOx65FUbj4lY=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd h1:EDPBXCAspyGV4jQlpZSudPeMmr1bNJefnuqLsRAsHZo=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd/go.mod h1:B8JuhiUyNFVKdsE8h686QcCxMaH6HrOAZj4vswFpcB0=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1240,7 +1240,7 @@ kmodules.xyz/monitoring-agent-api/api/v1
 # kmodules.xyz/offshoot-api v0.30.1
 ## explicit; go 1.22.0
 kmodules.xyz/offshoot-api/api/v1
-# kubevault.dev/apimachinery v0.20.0-rc.0
+# kubevault.dev/apimachinery v0.20.0
 ## explicit; go 1.22.1
 kubevault.dev/apimachinery/apis
 kubevault.dev/apimachinery/apis/catalog


### PR DESCRIPTION
ProductLine: KubeVault
Release: v2025.2.10
Release-tracker: https://github.com/kubevault/CHANGELOG/pull/56
Signed-off-by: 1gtm <1gtm@appscode.com>