### PR TITLE
Prepare for release v0.21.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	k8s.io/kubectl v0.30.2
 	kmodules.xyz/client-go v0.32.4
 	kmodules.xyz/custom-resources v0.32.0
-	kubevault.dev/apimachinery v0.20.1-0.20250525020906-6afe114bf0a3
+	kubevault.dev/apimachinery v0.21.0
 	sigs.k8s.io/secrets-store-csi-driver v1.5.1
 	sigs.k8s.io/yaml v1.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -758,8 +758,8 @@ kmodules.xyz/monitoring-agent-api v0.32.0 h1:cMQbWvbTc4JWeLI/zYE0HLefsdFYBzqvATL
 kmodules.xyz/monitoring-agent-api v0.32.0/go.mod h1:zgRKiJcuK7FOHy0Y1TsONRbJfgnPCs8t4Zh/6Afr+yU=
 kmodules.xyz/offshoot-api v0.30.1 h1:TrulAYO+oBsXe9sZZGTmNWIuI8qD2izMpgcTSPvgAmI=
 kmodules.xyz/offshoot-api v0.30.1/go.mod h1:T3mpjR6fui0QzOcmQvIuANytW48fe9ytmy/1cgx6D4g=
-kubevault.dev/apimachinery v0.20.1-0.20250525020906-6afe114bf0a3 h1:BVC9+3MV3jvQSaeZ6Eq/1elgxX0ly8ewyTk9nWgI7+w=
-kubevault.dev/apimachinery v0.20.1-0.20250525020906-6afe114bf0a3/go.mod h1:QArlKB79Ho4PauRS2ioX4FEVjF79EbwAaomXhkLC/Hk=
+kubevault.dev/apimachinery v0.21.0 h1:H+Cn6aRw+W1PSjKdG3qX0F/YqA55/HsnSYHzIyS7k8I=
+kubevault.dev/apimachinery v0.21.0/go.mod h1:QArlKB79Ho4PauRS2ioX4FEVjF79EbwAaomXhkLC/Hk=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 h1:gBQPwqORJ8d8/YNZWEjoZs7npUVDpVXUUOFfW6CgAqE=
 sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1387,7 +1387,7 @@ kmodules.xyz/monitoring-agent-api/api/v1
 # kmodules.xyz/offshoot-api v0.30.1
 ## explicit; go 1.22.0
 kmodules.xyz/offshoot-api/api/v1
-# kubevault.dev/apimachinery v0.20.1-0.20250525020906-6afe114bf0a3
+# kubevault.dev/apimachinery v0.21.0
 ## explicit; go 1.23.0
 kubevault.dev/apimachinery/apis
 kubevault.dev/apimachinery/apis/catalog


### PR DESCRIPTION
ProductLine: KubeVault
Release: v2025.5.26
Release-tracker: https://github.com/kubevault/CHANGELOG/pull/58
Signed-off-by: 1gtm <1gtm@appscode.com>