### PR TITLE
Prepare for release v0.22.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	k8s.io/kubectl v0.30.2
 	kmodules.xyz/client-go v0.32.4
 	kmodules.xyz/custom-resources v0.32.0
-	kubevault.dev/apimachinery v0.21.0
+	kubevault.dev/apimachinery v0.22.0
 	sigs.k8s.io/secrets-store-csi-driver v1.5.1
 	sigs.k8s.io/yaml v1.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -758,8 +758,8 @@ kmodules.xyz/monitoring-agent-api v0.32.0 h1:cMQbWvbTc4JWeLI/zYE0HLefsdFYBzqvATL
 kmodules.xyz/monitoring-agent-api v0.32.0/go.mod h1:zgRKiJcuK7FOHy0Y1TsONRbJfgnPCs8t4Zh/6Afr+yU=
 kmodules.xyz/offshoot-api v0.30.1 h1:TrulAYO+oBsXe9sZZGTmNWIuI8qD2izMpgcTSPvgAmI=
 kmodules.xyz/offshoot-api v0.30.1/go.mod h1:T3mpjR6fui0QzOcmQvIuANytW48fe9ytmy/1cgx6D4g=
-kubevault.dev/apimachinery v0.21.0 h1:H+Cn6aRw+W1PSjKdG3qX0F/YqA55/HsnSYHzIyS7k8I=
-kubevault.dev/apimachinery v0.21.0/go.mod h1:QArlKB79Ho4PauRS2ioX4FEVjF79EbwAaomXhkLC/Hk=
+kubevault.dev/apimachinery v0.22.0 h1:6ysCHgKe0Sw2z35UkpiA8xfWwsGMmzpLEw6RDp5HF/k=
+kubevault.dev/apimachinery v0.22.0/go.mod h1:QArlKB79Ho4PauRS2ioX4FEVjF79EbwAaomXhkLC/Hk=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 h1:gBQPwqORJ8d8/YNZWEjoZs7npUVDpVXUUOFfW6CgAqE=
 sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=

--- a/vendor/kubevault.dev/apimachinery/apis/engine/v1alpha1/openapi_generated.go
+++ b/vendor/kubevault.dev/apimachinery/apis/engine/v1alpha1/openapi_generated.go
@@ -23407,27 +23407,6 @@ func schema_apimachinery_apis_engine_v1alpha1_ElasticsearchConfiguration(ref com
 							Format:      "",
 						},
 					},
-					"url": {
-						SchemaProps: spec.SchemaProps{
-							Description: "The URL for Elasticsearch's API (\"http://localhost:9200\").",
-							Type:        []string{"string"},
-							Format:      "",
-						},
-					},
-					"username": {
-						SchemaProps: spec.SchemaProps{
-							Description: "The username to be used in the connection URL (\"vault\").",
-							Type:        []string{"string"},
-							Format:      "",
-						},
-					},
-					"password": {
-						SchemaProps: spec.SchemaProps{
-							Description: "The password to be used in the connection URL (\"pa55w0rd\").",
-							Type:        []string{"string"},
-							Format:      "",
-						},
-					},
 					"caCert": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The path to a PEM-encoded CA cert file to use to verify the Elasticsearch server's identity.",

--- a/vendor/kubevault.dev/apimachinery/apis/engine/v1alpha1/secret_engine_types.go
+++ b/vendor/kubevault.dev/apimachinery/apis/engine/v1alpha1/secret_engine_types.go
@@ -345,18 +345,6 @@ type ElasticsearchConfiguration struct {
 	//  - for elasticsearch: elasticsearch-database-plugin
 	PluginName string `json:"pluginName,omitempty"`
 
-	// The URL for Elasticsearch's API ("http://localhost:9200").
-	// +kubebuilder:validation:Required
-	Url string `json:"url,omitempty"`
-
-	// The username to be used in the connection URL ("vault").
-	// +kubebuilder:validation:Required
-	Username string `json:"username,omitempty"`
-
-	// The password to be used in the connection URL ("pa55w0rd").
-	// +kubebuilder:validation:Required
-	Password string `json:"password,omitempty"`
-
 	// The path to a PEM-encoded CA cert file to use to verify the Elasticsearch server's identity.
 	CACert string `json:"caCert,omitempty"`
 

--- a/vendor/kubevault.dev/apimachinery/crds/engine.kubevault.com_secretengines.yaml
+++ b/vendor/kubevault.dev/apimachinery/crds/engine.kubevault.com_secretengines.yaml
@@ -179,9 +179,6 @@ spec:
                     description: Not recommended. Default to false. Can be set to
                       true to disable SSL verification.
                     type: boolean
-                  password:
-                    description: The password to be used in the connection URL ("pa55w0rd").
-                    type: string
                   pluginName:
                     description: |-
                       Specifies the name of the plugin to use for this connection.
@@ -192,17 +189,8 @@ spec:
                     description: This, if set, is used to set the SNI host when connecting
                       via 1TLS.
                     type: string
-                  url:
-                    description: The URL for Elasticsearch's API ("http://localhost:9200").
-                    type: string
-                  username:
-                    description: The username to be used in the connection URL ("vault").
-                    type: string
                 required:
                 - databaseRef
-                - password
-                - url
-                - username
                 type: object
               gcp:
                 description: |-

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1387,7 +1387,7 @@ kmodules.xyz/monitoring-agent-api/api/v1
 # kmodules.xyz/offshoot-api v0.30.1
 ## explicit; go 1.22.0
 kmodules.xyz/offshoot-api/api/v1
-# kubevault.dev/apimachinery v0.21.0
+# kubevault.dev/apimachinery v0.22.0
 ## explicit; go 1.23.0
 kubevault.dev/apimachinery/apis
 kubevault.dev/apimachinery/apis/catalog


### PR DESCRIPTION
ProductLine: KubeVault
Release: v2025.5.30
Release-tracker: https://github.com/kubevault/CHANGELOG/pull/59
Signed-off-by: 1gtm <1gtm@appscode.com>