### PR TITLE
Prepare for release v0.25.0-rc.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	k8s.io/kubectl v0.30.2
 	kmodules.xyz/client-go v0.34.3
 	kmodules.xyz/custom-resources v0.34.0
-	kubevault.dev/apimachinery v0.25.0-rc.0
+	kubevault.dev/apimachinery v0.25.0-rc.1
 	sigs.k8s.io/secrets-store-csi-driver v1.5.1
 	sigs.k8s.io/yaml v1.6.0
 )

--- a/go.sum
+++ b/go.sum
@@ -797,8 +797,8 @@ kmodules.xyz/monitoring-agent-api v0.34.0 h1:SNgKvC1j8oYWQcdClyV2T5GsOQoG40c3pK9
 kmodules.xyz/monitoring-agent-api v0.34.0/go.mod h1:XFDfMHDZQeNEPdTDeDr4M0dT4UCWs+4IYzgHw7JDlms=
 kmodules.xyz/offshoot-api v0.34.0 h1:HnOOp8FrCjTWjtNApRDo6Ahe79tOlLrJmyye4xxO4Kk=
 kmodules.xyz/offshoot-api v0.34.0/go.mod h1:F+B59yYw4CZJ4uD4xu6C+mMLzIXUtuH7E+SbDICl9jE=
-kubevault.dev/apimachinery v0.25.0-rc.0 h1:Z452x6RME39Bje4nj7fv0B74/yN5yZwZdHf1+iY8BD0=
-kubevault.dev/apimachinery v0.25.0-rc.0/go.mod h1:ifyH1K2IK6iIFuE2RjDouAIRweEHBTMEXxAiEroB+JA=
+kubevault.dev/apimachinery v0.25.0-rc.1 h1:T0EPQJ8PYNlJj4SRblBOCtxlyfXmMga8/rkGNgvvNsU=
+kubevault.dev/apimachinery v0.25.0-rc.1/go.mod h1:ifyH1K2IK6iIFuE2RjDouAIRweEHBTMEXxAiEroB+JA=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5EXP7sU1kvOlxwZh5txg=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1436,7 +1436,7 @@ kmodules.xyz/monitoring-agent-api/api/v1
 # kmodules.xyz/offshoot-api v0.34.0
 ## explicit; go 1.24.0
 kmodules.xyz/offshoot-api/api/v1
-# kubevault.dev/apimachinery v0.25.0-rc.0
+# kubevault.dev/apimachinery v0.25.0-rc.1
 ## explicit; go 1.25.0
 kubevault.dev/apimachinery/apis
 kubevault.dev/apimachinery/apis/catalog


### PR DESCRIPTION
ProductLine: KubeVault
Release: v2026.5.18-rc.1
Release-tracker: https://github.com/kubevault/CHANGELOG/pull/69
Signed-off-by: 1gtm <1gtm@appscode.com>